### PR TITLE
HEEP-921 Read Analog Moisture Data

### DIFF
--- a/SoilHygrometer/HeepDeviceDefinitions.h
+++ b/SoilHygrometer/HeepDeviceDefinitions.h
@@ -2,7 +2,7 @@
 #include "ESP8266_HeepComms.h"
 #include "ESP8266_NonVolatileMemory.h"
 #include "Arduino_Timer.h" 
-heepByte deviceIDByte [STANDARD_ID_SIZE] = {0x00, 0x00, 0x00, 0x00};
-uint8_t mac[6] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+heepByte deviceIDByte [STANDARD_ID_SIZE] = {0xe0, 0x0e,0xd0, 0x0d};
+uint8_t mac[6] = {0x0a, 0xb0, 0x0c, 0xd0, 0x0e, 0xf0};
 unsigned char clearMemory = 1;
 char* heepDeviceName = "SoilHygrometer";

--- a/SoilHygrometer/SoilHygrometer.ino
+++ b/SoilHygrometer/SoilHygrometer.ino
@@ -2,14 +2,34 @@
 #include "HeepDeviceDefinitions.h"
 
 #define WATERME_PIN 14
+#define ANALOG_PIN A0
+
+unsigned long previousMillis = 0;
 
 void InitializeControlHardware(){
   pinMode(WATERME_PIN,INPUT);
+  pinMode(ANALOG_PIN,INPUT);
 }
 
 int ReadWaterMe(){
   int currentSetting = digitalRead(WATERME_PIN);
-  SetControlValueByName("WaterMe",currentSetting);
+  SetControlValueByName("DigitalWaterMe",currentSetting);
+  return currentSetting;
+}
+
+int ReadAnalog(){
+  int currentSetting = analogRead(ANALOG_PIN) / 10;
+  SetControlValueByName("Moistness", currentSetting);
+
+  if (currentSetting >  GetControlValueByName("TriggerValue")) {
+    SetControlValueByName("AnalogWaterMe", true);
+  } else {
+    SetControlValueByName("AnalogWaterMe", false);
+  }
+  
+  Serial.print("Moistness: ");
+  Serial.println(currentSetting);
+  
   return currentSetting;
 }
 
@@ -18,14 +38,36 @@ void setup()
 
   Serial.begin(115200);
   InitializeControlHardware();
-  AddOnOffControl("WaterMe",HEEP_OUTPUT,0);
-  StartHeep(heepDeviceName, 2);
+
+  std::string SSID1 = "ssid";
+  std::string Password1 = "password";
+  AddWiFiSettingsToMemory(&SSID1[0], SSID1.length(), &Password1[0], Password1.length(), deviceIDByte, 0);
+  
+  AddOnOffControl("DigitalWaterMe",HEEP_OUTPUT,0);
+  AddOnOffControl("AnalogWaterMe",HEEP_OUTPUT,0);
+  AddRangeControl("Moistness",HEEP_OUTPUT, 100, 0, 0);
+  
+  AddRangeControl("TriggerValue",HEEP_INPUT, 100, 0, 70);
+  AddRangeControl("ReadFrequency",HEEP_INPUT, 100, 0, 3);
+  
+  StartHeep(heepDeviceName, 12);
 
 }
 
 void loop()
 {
   PerformHeepTasks();
-  ReadWaterMe();
+
+  unsigned long currentMillis = millis();
+
+  if (currentMillis - previousMillis >= 1000 * GetControlValueByName("ReadFrequency")) {
+    previousMillis = currentMillis;
+
+    ReadWaterMe();
+    ReadAnalog();
+    
+  }
+  
+  
 
 }


### PR DESCRIPTION
This PR adds a few new inputs and outputs to the soil hygrometer to make it a bit more useful. Most importantly, analog values are read from the sensor. The user can also now set the read frequency, enabling extended lifetime of the sensor before corrosion degrades the data quality. The user can use an input to set the analog trigger value. This allows you to tweak parameters to adjust the sensor to reflect the needs of the plant it is sensing for - some plants need to maintain a more moist environment, others less so. 

<img width="248" alt="screen shot 2018-05-27 at 2 50 11 pm" src="https://user-images.githubusercontent.com/3604149/40589555-4a035108-61bd-11e8-9dc3-2ef7e9421f41.png">
